### PR TITLE
Update helm-tracker.el

### DIFF
--- a/helm-tracker.el
+++ b/helm-tracker.el
@@ -28,7 +28,7 @@
 ;;; Code:
 (require 'helm)
 
-(defgroup 'helm-tracker nil
+(defgroup helm-tracker nil
   "helm interface for gnome tracker")
 
 (defcustom helm-tracker-max-results 512


### PR DESCRIPTION
The name of the group in defgroup [should not be quotes](https://www.gnu.org/software/emacs/manual/html_node/elisp/Group-Definitions.html) and the package does not load with the quote included.